### PR TITLE
Add Unlit Soul Lantern

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs = -Xmx1G
 
 minecraft = 1.19
 mappings = 1.19+build.1
-fabric_loader = 0.14.6
+fabric_loader = 0.14.7
 fabric_api = 0.55.3+1.19
 cloth_config = 7.0.69
 mod_menu = 4.0.0

--- a/src/main/java/io/github/realguyman/totally_lit/TotallyLitClientInitializer.java
+++ b/src/main/java/io/github/realguyman/totally_lit/TotallyLitClientInitializer.java
@@ -9,6 +9,6 @@ import static io.github.realguyman.totally_lit.registry.BlockRegistry.*;
 public class TotallyLitClientInitializer implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-        BlockRenderLayerMap.INSTANCE.putBlocks(RenderLayer.getCutout(), GLOWSTONE_LANTERN, GLOWSTONE_TORCH, GLOWSTONE_WALL_TORCH, UNLIT_LANTERN, UNLIT_SOUL_TORCH, UNLIT_SOUL_WALL_TORCH, UNLIT_TORCH, UNLIT_WALL_TORCH);
+        BlockRenderLayerMap.INSTANCE.putBlocks(RenderLayer.getCutout(), GLOWSTONE_LANTERN, GLOWSTONE_TORCH, GLOWSTONE_WALL_TORCH, UNLIT_LANTERN, UNLIT_SOUL_LANTERN, UNLIT_SOUL_TORCH, UNLIT_SOUL_WALL_TORCH, UNLIT_TORCH, UNLIT_WALL_TORCH);
     }
 }

--- a/src/main/java/io/github/realguyman/totally_lit/registry/BlockRegistry.java
+++ b/src/main/java/io/github/realguyman/totally_lit/registry/BlockRegistry.java
@@ -14,6 +14,7 @@ public class BlockRegistry {
     public static final Block GLOWSTONE_WALL_TORCH = add("glowstone_wall_torch", new NoParticleWallTorchBlock(Settings.copy(Blocks.TORCH).dropsLike(GLOWSTONE_TORCH)));
     public static final Block GLOWSTONE_LANTERN = add("glowstone_lantern", new LanternBlock(Settings.copy(Blocks.LANTERN)));
     public static final Block UNLIT_LANTERN = add("unlit_lantern", new UnlitLanternBlock(Settings.copy(Blocks.LANTERN).luminance(state -> 0), Blocks.LANTERN));
+    public static final Block UNLIT_SOUL_LANTERN = add("unlit_soul_lantern", new UnlitLanternBlock(Settings.copy(UNLIT_LANTERN), Blocks.SOUL_LANTERN));
     public static final Block UNLIT_SOUL_TORCH = add("unlit_soul_torch", new UnlitTorchBlock(Settings.copy(Blocks.TORCH).luminance(state -> 0), Blocks.SOUL_TORCH));
     public static final Block UNLIT_SOUL_WALL_TORCH = add("unlit_soul_wall_torch", new UnlitWallTorchBlock(Settings.copy(Blocks.WALL_TORCH).luminance(state -> 0).dropsLike(UNLIT_SOUL_TORCH), Blocks.SOUL_WALL_TORCH));
     public static final Block UNLIT_TORCH = add("unlit_torch", new UnlitTorchBlock(Settings.copy(Blocks.TORCH).luminance(state -> 0), Blocks.TORCH));

--- a/src/main/java/io/github/realguyman/totally_lit/registry/ItemRegistry.java
+++ b/src/main/java/io/github/realguyman/totally_lit/registry/ItemRegistry.java
@@ -11,6 +11,7 @@ public class ItemRegistry {
     public static final Item GLOWSTONE_TORCH = add("glowstone_torch", new WallStandingBlockItem(BlockRegistry.GLOWSTONE_TORCH, BlockRegistry.GLOWSTONE_WALL_TORCH, new Item.Settings().group(ItemGroup.DECORATIONS)));
     public static final Item GLOWSTONE_LANTERN = add("glowstone_lantern", new BlockItem(BlockRegistry.GLOWSTONE_LANTERN, new Item.Settings().group(ItemGroup.DECORATIONS)));
     public static final Item UNLIT_LANTERN = add("unlit_lantern", new UnlitLanternItem(BlockRegistry.UNLIT_LANTERN, new Item.Settings().group(ItemGroup.DECORATIONS), Items.LANTERN));
+    public static final Item UNLIT_SOUL_LANTERN = add("unlit_soul_lantern", new UnlitLanternItem(BlockRegistry.UNLIT_SOUL_LANTERN, new Item.Settings().group(ItemGroup.DECORATIONS), Items.SOUL_LANTERN));
     public static final Item UNLIT_SOUL_TORCH = add("unlit_soul_torch", new UnlitTorchItem(BlockRegistry.UNLIT_SOUL_TORCH, BlockRegistry.UNLIT_SOUL_WALL_TORCH, new Item.Settings().group(ItemGroup.DECORATIONS), Items.SOUL_TORCH));
     public static final Item UNLIT_TORCH = add("unlit_torch", new UnlitTorchItem(BlockRegistry.UNLIT_TORCH, BlockRegistry.UNLIT_WALL_TORCH, new Item.Settings().group(ItemGroup.DECORATIONS), Items.TORCH));
 

--- a/src/main/resources/assets/totally_lit/blockstates/unlit_soul_lantern.json
+++ b/src/main/resources/assets/totally_lit/blockstates/unlit_soul_lantern.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "hanging=false": {
+      "model": "totally_lit:block/unlit_lantern"
+    },
+    "hanging=true": {
+      "model": "totally_lit:block/unlit_lantern_hanging"
+    }
+  }
+}

--- a/src/main/resources/assets/totally_lit/lang/en_us.json
+++ b/src/main/resources/assets/totally_lit/lang/en_us.json
@@ -2,6 +2,7 @@
   "block.totally_lit.glowstone_lantern": "Glowstone Lantern",
   "block.totally_lit.glowstone_torch": "Glowstone Torch",
   "block.totally_lit.unlit_lantern": "Unlit Lantern",
+  "block.totally_lit.unlit_soul_lantern": "Unlit Soul Lantern",
   "block.totally_lit.unlit_soul_torch": "Unlit Soul Torch",
   "block.totally_lit.unlit_torch": "Unlit Torch",
   "text.autoconfig.totally_lit.category.campfires": "Campfires",

--- a/src/main/resources/assets/totally_lit/models/item/unlit_soul_lantern.json
+++ b/src/main/resources/assets/totally_lit/models/item/unlit_soul_lantern.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "totally_lit:item/unlit_lantern"
+  }
+}

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": [
     "totally_lit:glowstone_lantern",
-    "totally_lit:unlit_lantern"
+    "totally_lit:unlit_lantern",
+    "totally_lit:unlit_soul_lantern"
   ]
 }

--- a/src/main/resources/data/totally_lit/loot_tables/blocks/unlit_soul_lantern.json
+++ b/src/main/resources/data/totally_lit/loot_tables/blocks/unlit_soul_lantern.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "totally_lit:unlit_soul_lantern",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/totally_lit/recipes/unlit_soul_lantern.json
+++ b/src/main/resources/data/totally_lit/recipes/unlit_soul_lantern.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "iii",
+    "iui",
+    "iii"
+  ],
+  "key": {
+    "i": [
+      {
+        "item": "minecraft:iron_nugget"
+      }
+    ],
+    "u": [
+      {
+        "item": "totally_lit:unlit_soul_torch"
+      }
+    ]
+  },
+  "result": {
+    "item": "totally_lit:unlit_soul_lantern"
+  }
+}


### PR DESCRIPTION
https://github.com/realguyman/totally_lit/discussions/11 was already completed via https://github.com/realguyman/totally_lit/commit/3639b7b11897e8da65498949e897ccdb501170f3. Since there is an unlit variant of soul torches, I implemented an unlit variant for soul lanterns to remain consistent.