### PR TITLE
Fix unlit torch loot tables for 1.21.1

### DIFF
--- a/src/main/java/io/github/realguyman/totally_lit/registry/BlockRegistry.java
+++ b/src/main/java/io/github/realguyman/totally_lit/registry/BlockRegistry.java
@@ -84,7 +84,7 @@ public class BlockRegistry {
         UNLIT_SOUL_WALL_TORCH = add(
                 "unlit_soul_wall_torch",
                 new NoParticleWallTorchBlock(
-                        Settings.copy(Blocks.WALL_TORCH)
+                        Settings.copy(Blocks.WALL_TORCH).dropsLike(UNLIT_SOUL_TORCH)
                                 .luminance(state -> 0)
                 )
         );
@@ -98,7 +98,7 @@ public class BlockRegistry {
 
         UNLIT_WALL_TORCH = add("unlit_wall_torch",
                 new NoParticleWallTorchBlock(
-                        Settings.copy(Blocks.WALL_TORCH)
+                        Settings.copy(Blocks.WALL_TORCH).dropsLike(UNLIT_TORCH)
                                 .luminance(state -> 0)
                 )
         );


### PR DESCRIPTION
Theres an oversight with unlit torch types placed on walls dropping their lit counterparts when broken. This PR fixes that